### PR TITLE
ログイン/ログアウト後の商品一覧画面へのリダイレクト処理を修正

### DIFF
--- a/src/routes/login.js
+++ b/src/routes/login.js
@@ -16,7 +16,7 @@ export default async function loginRoutes(server, options) {
       }),
     },
     async (request, reply) => {
-      reply.redirect("/items");
+      await reply.redirect("/items");
     }
   );
 
@@ -24,7 +24,7 @@ export default async function loginRoutes(server, options) {
     '/logout',
     async (request, reply) => {
       await request.logOut()
-      reply.redirect(302, '/login')
+      await reply.redirect(302, '/login')
     }
   )
 }

--- a/src/routes/login.js
+++ b/src/routes/login.js
@@ -12,7 +12,6 @@ export default async function loginRoutes(server, options) {
     "/login",
     {
       preValidation: passport.authenticate("local", {
-        successRedirect: "/items",
         authInfo: false,
       }),
     },


### PR DESCRIPTION
## Description of the PR

- `src/routes/login.js` について、ログイン/ログアウト後の商品一覧画面へのリダイレクト処理を修正
- Resolves https://github.com/tsuemura/practical-guide-for-test-automation-support/issues/4

### 📝Summary of the issue #4

- ローカル環境でのE2Eテスト実行時、下記のエラーが発生してE2Eテストが失敗していた

<details>

```bash
$ npm run test:e2e

> fastify-react-sample@1.0.0 test:e2e
> npx start-server-and-test dev http://localhost:8080 'cd e2e && npm run test'

1: starting server using command "npm run dev"
and when url "[ 'http://localhost:8080' ]" is responding with HTTP status code 200
running tests using command "cd e2e && npm run test"


> fastify-react-sample@1.0.0 dev
> nodemon src/index.js

[nodemon] 2.0.20
[nodemon] to restart at any time, enter `rs`
[nodemon] watching path(s): src/**/*
[nodemon] watching extensions: ts,mjs,ejs,js,json,graphql
[nodemon] starting `node src/index.js`
Server listening at http://0.0.0.0:8080

> e2e@1.0.0 test
> codeceptjs run --steps

CodeceptJS v3.3.7 #StandWithUkraine
Using test root "/app/e2e"

一般的なエラーのテスト --
  ユーザーが存在しないURLにアクセスすると、エラーメッセージと商品一覧へのリンクが表示される
    I am on page "/undefined"
    I see "お探しのページは見つかりませんでした。"
    I click "商品一覧へ戻る"
    I see in title "商品一覧"
  ✔ OK in 1120ms

スモークテスト --
  example.comにアクセスする
    I am on page "https://example.com"
    I see "Example Domain"
  ✔ OK in 997ms

  Webサイトを開きログインする
    I am on page "/"
    I click "ログインする"
    I fill field "ユーザー名", "user1"
    I fill field "パスワード", "super-strong-passphrase"
    I click "ログイン"
node:_http_server:345
    throw new ERR_HTTP_HEADERS_SENT('write');
    ^

Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent to the client
    at ServerResponse.writeHead (node:_http_server:345:11)
    at onSendEnd (/app/node_modules/fastify/lib/reply.js:571:9)
    at wrapOnSendEnd (/app/node_modules/fastify/lib/reply.js:537:5)
    at next (/app/node_modules/fastify/lib/hooks.js:213:7)
    at /app/node_modules/@fastify/session/lib/fastifySession.js:190:9
    at /app/node_modules/@fastify/session/lib/session.js:171:9
    at /app/node_modules/connect-pg-simple/index.js:396:24
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  code: 'ERR_HTTP_HEADERS_SENT'
}

Node.js v20.16.0
[nodemon] app crashed - waiting for file changes before starting...
    I see "user1 さん"
  ✖ FAILED in 2258ms


-- FAILURES:

  1) スモークテスト
       Webサイトを開きログインする:

      expected web application to include "user1 さん"
      + expected - actual

      +user1 さん
      
  
  
  Scenario Steps:
  - I.see("user1 さん") at Test.<anonymous> (./smoke_test.js:14:5)
  - I.click("ログイン") at Test.<anonymous> (./smoke_test.js:13:5)
  - I.fillField("パスワード", "super-strong-passphrase") at Test.<anonymous> (./smoke_test.js:12:5)
  - I.fillField("ユーザー名", "user1") at Test.<anonymous> (./smoke_test.js:11:5)
  - I.click("ログインする") at Test.<anonymous> (./smoke_test.js:10:5)
  - I.amOnPage("/") at Test.<anonymous> (./smoke_test.js:9:5)
  
  Artifacts:
  - screenshots: /app/e2e/output/record_454d187ec3888c7134731f2985d4d593/0000.png,/app/e2e/output/record_454d187ec3888c7134731f2985d4d593/0001.png,/app/e2e/output/record_454d187ec3888c7134731f2985d4d593/0002.png,/app/e2e/output/record_454d187ec3888c7134731f2985d4d593/0003.png,/app/e2e/output/record_454d187ec3888c7134731f2985d4d593/0004.png,/app/e2e/output/record_454d187ec3888c7134731f2985d4d593/0005.png
  - screenshot: /app/e2e/output/Webサイトを開きログインする.failed.png


  FAIL  | 2 passed, 1 failed   // 5s
Run with --verbose flag to see complete NodeJS stacktrace
◉ Step-by-step preview: file:///app/e2e/output/records.html
Error: Command failed with exit code 1: cd e2e && npm run test
    at makeError (/app/node_modules/execa/lib/error.js:60:11)
    at handlePromise (/app/node_modules/execa/index.js:118:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  shortMessage: 'Command failed with exit code 1: cd e2e && npm run test',
  command: 'cd e2e && npm run test',
  escapedCommand: '"cd e2e && npm run test"',
  exitCode: 1,
  signal: undefined,
  signalDescription: undefined,
  stdout: undefined,
  stderr: undefined,
  failed: true,
  timedOut: false,
  isCanceled: false,
  killed: false
}
```

</details>

- 手動でもテスト実行して確認してみたところ、ログイン処理とログアウト処理にて、前述のエラー `Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent to the client` が発生した

### 🐞Fix summary in the PR

- `passport.authenticate()` のパラメータ `successRedirect` を削除
  - コールバック内に `reply.redirect('/items')` のリダイレクト処理があり、上記は不要なため
- コールバック内の `reply.redirect('/items')` 直前に `await` を付与し、処理結果を待機するように変更
  - 商品一覧画面へのリダイレクト完了を待たずにレスポンスが返されることを避けるため

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [x] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm run test:e2e` at project root)
